### PR TITLE
Allow to specify type, format, constraints

### DIFF
--- a/darwin-core-data-package-guide.md
+++ b/darwin-core-data-package-guide.md
@@ -139,7 +139,7 @@ This dataset can be described as a DwC-DP with the following **descriptor** (`da
             "name": "eventDate",
             "title": "Event Date",
             "description": "A date or time interval during which a dwc:Event occurred.",
-            "type": "string",
+            "type": "datetime",
             "format": "default",
             "dcterms:isVersionOf": "http://rs.tdwg.org/dwc/terms/eventDate",
             "dcterms:references": "http://rs.tdwg.org/dwc/terms/version/eventDate-2025-06-12"
@@ -169,7 +169,7 @@ This dataset can be described as a DwC-DP with the following **descriptor** (`da
             "name": "occurrenceID",
             "title": "Occurrence ID",
             "description": "An identifier for a dwc:Occurrence.",
-            "type": "string",
+            "type": "integer",
             "format": "default",
             "dcterms:isVersionOf": "http://rs.tdwg.org/dwc/terms/occurrenceID",
             "dcterms:references": "http://rs.tdwg.org/dwc/terms/version/occurrenceID-2023-06-28"
@@ -196,7 +196,7 @@ This dataset can be described as a DwC-DP with the following **descriptor** (`da
             "name": "organismQuantity",
             "title": "Organism Quantity",
             "description": "A number or enumeration value for the quantity of dwc:Organisms.",
-            "type": "string",
+            "type": "integer",
             "format": "default",
             "dcterms:isVersionOf": "http://rs.tdwg.org/dwc/terms/organismQuantity",
             "dcterms:references": "http://rs.tdwg.org/dwc/terms/version/organismQuantity-2023-06-28"
@@ -208,7 +208,12 @@ This dataset can be described as a DwC-DP with the following **descriptor** (`da
             "type": "string",
             "format": "default",
             "dcterms:isVersionOf": "http://rs.tdwg.org/dwc/terms/organismQuantityType",
-            "dcterms:references": "http://rs.tdwg.org/dwc/terms/version/organismQuantityType-2023-06-28"
+            "dcterms:references": "http://rs.tdwg.org/dwc/terms/version/organismQuantityType-2023-06-28",
+            "constraints": {
+              "enum": [
+                "individuals"
+              ]
+            }
           }
         ],
         "primaryKey": ["occurrenceID"],
@@ -358,9 +363,9 @@ A **field descriptor** describes a single field in a table schema (e.g., name, d
 
 4. A field descriptor MAY have a `comments` property, with usage notes.
 
-5. A field descriptor MUST have a `type` property, indicating the data type of values in the field (e.g., `"string"`, `"number"`). It MUST follow the [Table schema specification][field.type].
+5. A field descriptor MUST have a `type` property, indicating the data type of values in the field (e.g., `"string"`, `"number"`). It MUST follow the [Table schema specification][field.type]. If the `type` provided in the table schema at `rs.tdwg.org` is `"any"`, then a more specific one MAY be defined.
 
-6. A field descriptor SHOULD have a `format` property, indicating how values should be parsed. It MUST follow the [Table schema specification](field.format).
+6. A field descriptor SHOULD have a `format` property, indicating how values should be parsed. It MUST follow the [Table schema specification](field.format). If the `format` provided in the table schema at `rs.tdwg.org` is `"default"`, then a more specific one MAY be defined.
 
 7. A field descriptor MUST have a `dcterms:isVersionOf` property, with the URL of the unversioned source term describing the field (e.g., `"http://rs.tdwg.org/dwc/terms/eventID"`).
 
@@ -370,7 +375,7 @@ A **field descriptor** describes a single field in a table schema (e.g., name, d
 
 10. A field descriptor MAY have a `namespace` property, with an abbreviation of the namespace of the source term (e.g., `"dwc"`, `"dcterms"`).
 
-11. A field descriptor MAY have a `constraints` property, indicating value requirements that SHOULD be used in validation. It MUST follow the [Table Schema specification][field.constraints].
+11. A field descriptor MAY have a `constraints` property, indicating value requirements that SHOULD be used in validation. It MUST follow the [Table Schema specification][field.constraints]. The `constraints` provided in the table schema at `rs.tdwg.org` MAY be updated, but it MUST NOT relax the original constraints.
 
 12. A field descriptor MAY have additional properties. This includes those defined by the [Table Schema specification][table-schema] (e.g., `example`) or custom properties.
 


### PR DESCRIPTION
Since we include the schemas verbosely, I think we should allow publishers to add more rigorous `type`, `format` and `constraints` than the one provided at `rs.tdwg.org`.

For `type` we have to be a bit careful, which is why I suggest to use `"type": "any"` in our table schemas for terms that can have multiple types. That would differentiate:

`eventDate`: can be `string` or `datetime`

From

`eventType`: must always be a `string`

The implementation rule for `"any"` is that there must be [no processing](https://datapackage.org/standard/table-schema/#any). For CSVs that means those values are interpreted as strings.

@tucotuco you probably have a better overview of terms that can deviate from strings?